### PR TITLE
deps updated due to build problems on node v11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
   - TRAVIS_NODE_VERSION="8"
   - TRAVIS_NODE_VERSION="9"
   - TRAVIS_NODE_VERSION="10"
+  - TRAVIS_NODE_VERSION="11"
 
 before_install:
 - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
     - {"nodejs_version": "8", "npm_version": "4"}
     - {"nodejs_version": "9", "npm_version": "5"}
     - {"nodejs_version": "10", "npm_version": "6"}
+    - {"nodejs_version": "11", "npm_version": "6"}
 
 platform:
   - x86

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bluebird": "^3.5.1",
     "commander": "^2.17.0",
     "murmurhash3js": "^3.0.1",
-    "node-pre-gyp-github": "^1.4.2",
+    "node-pre-gyp-github": "1.3.1",
     "tap": "^9.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "commander": "^2.17.0",
     "murmurhash3js": "^3.0.1",
     "node-pre-gyp-github": "^1.4.2",
-    "tap": "^12.0.1"
+    "tap": "^9.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "node": ">=4"
   },
   "dependencies": {
-    "nan": "^2.10.0",
-    "node-pre-gyp": "^0.10.3"
+    "nan": "^2.11.1",
+    "node-pre-gyp": "^0.11.0"
   },
   "devDependencies": {
     "bluebird": "^3.5.1",
     "commander": "^2.17.0",
     "murmurhash3js": "^3.0.1",
-    "node-pre-gyp-github": "1.3.1",
-    "tap": "^9.0.3"
+    "node-pre-gyp-github": "^1.4.2",
+    "tap": "^12.0.1"
   }
 }


### PR DESCRIPTION
All outdated dependencies are updated to the latest versions with this PR.
I found that as a solution to the following problem:
I have a module which depends on `murmurhash-native`. My module prefers to be installed globally. 
When I'm running `npm i -g mymodule` from npm, installation fails with the following error on node v11+:
~~~
sed: can't read ./Release/.deps/Release/obj.target/murmurhash/src/murmurhash/MurmurHash2.o.d.raw: No such file or directory
rm: cannot remove './Release/.deps/Release/obj.target/murmurhash/src/murmurhash/MurmurHash2.o.d.raw': No such file or directory
murmurhash.target.mk:113: recipe for target 'Release/obj.target/murmurhash/src/murmurhash/MurmurHash2.o' failed
make: *** [Release/obj.target/murmurhash/src/murmurhash/MurmurHash2.o] Error 1
make: Leaving directory '/home/mstadnik/.nvm/versions/node/v11.1.0/lib/node_modules/@imqueue/cli/node_modules/murmurhash-native/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit
~~~
Updating deps as in this pull request fixes the problem for me on node 11. This problem occurs for me ONLY on node version 11.0.0 and above and in the case `murmurhash-native` as a dependency of globally installed package...
Could you, please, suggest to accept this PR?
Thank you in advance!