### PR TITLE
chore: bump node-pre-gyp for CVE-2020-7598

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "nan": "^2.14.1",
-    "node-pre-gyp": "^0.14.0"
+    "node-pre-gyp": "^0.17.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.30",


### PR DESCRIPTION
The current version of `node-pre-gyp` is vulnerable to CVE-2020-7598 via inclusion of a vulnerable `minimist` version. This PR patches the vuln by upgrading `node-pre-gyp` from 0.14.0 to 0.17.0.

References:
- CVE-2020-7598 advisory: https://github.com/advisories/GHSA-vh95-rmgr-6w4m
- `node-pre-gyp` changelog: https://github.com/mapbox/node-pre-gyp/blob/master/CHANGELOG.md