### PR TITLE
fix-1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var binary = require('node-pre-gyp');
+var binary = require('@mapbox/node-pre-gyp');
 var path = require('path');
 var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
 module.exports = require(binding_path);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "nan": "^2.14.1",
-    "node-pre-gyp": "^0.17.0"
+    "@mapbox/node-pre-gyp": "^1.0.7"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.30",


### PR DESCRIPTION
Switches to the latest version of `@mapbox/node-pre-gyp` to fix problems building from source via yarn.