### PR TITLE
ci: build and publish binaries when a release is published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
This will publish binaries same time we publish to npmjs. Hope this will work now 🤞🏻... don't want to create too many incomplete releases, but CI is annoying to test.